### PR TITLE
Add CSS to Select Information

### DIFF
--- a/front-end/src/HomeScreen.js
+++ b/front-end/src/HomeScreen.js
@@ -31,7 +31,7 @@ const HomeScreen = () => {
             <div className="home-links">
                 <a href="/edit-information" className="home-link">Edit Information</a>
                 <a href="/saved-connections" className="home-link">Saved Connections</a>
-                <a href="/generate-code" className="home-link">Generate Code</a>
+                <a href="/select-information" className="home-link">Generate Code</a>
             </div>
         </div>
     );

--- a/front-end/src/SelectInformationForm.css
+++ b/front-end/src/SelectInformationForm.css
@@ -1,0 +1,92 @@
+.select-information-header {
+    text-align: center;
+}
+
+/* Submit button and container CSS copied from EditInformation.css 10/29 */
+.select-information-form {
+    max-width: 400px;
+    margin: 0 auto;
+    padding: 20px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+}
+
+.select-information-submit-button {
+    width: 100%;
+    padding: 10px;
+    background-color: #007bff;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+    margin-top: 10px;
+}
+
+.select-information-submit-button:hover {
+    background-color: #0056b3;
+}
+
+/* Checkbox CSS adapted from
+ * https://www.w3schools.com/howto/howto_css_switch.asp 
+ */
+.select-information-checkbox {
+    float: right;
+    position: relative;
+    width: 30px;
+    height: 17px;
+}
+
+.select-information-checkbox input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 13px;
+  width: 13px;
+  left: 2px;
+  bottom: 2px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+input:checked + .slider {
+  background-color: #2196F3;
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(13px);
+  -ms-transform: translateX(13px);
+  transform: translateX(13px);
+}
+
+/* Rounded sliders */
+.slider {
+  border-radius: 17px;
+}
+
+.slider:before {
+  border-radius: 50%;
+}
+

--- a/front-end/src/SelectInformationForm.js
+++ b/front-end/src/SelectInformationForm.js
@@ -55,27 +55,38 @@ const SelectInformationForm = props => {
   }, [checked])
 
   return (
-    <div>
-      <input type="checkbox"
-              checked={allChecked}
-              onChange={handleSelectAll} />
-      <label>Select All<br/></label>
+    <div className="select-information-form">
+      <div className="select-information-header">
+        <h2>Select Information</h2>
+      </div>
+      <label>Select All</label>
+      <label className="select-information-checkbox">
+          <input type="checkbox"
+                  checked={allChecked}
+                  onChange={handleSelectAll} />
+        <span className="slider"></span>
+      </label>
+      <hr/>
       <div>
       {data.map(item =>
-        <div key={`input-div${item.id}`}>
-          <input key={`input${item.id}`}
-                id={item.id /* passed to update state */}
-                type="checkbox"
-                checked={checked[item.id - 1] || false /* was triggering an
-                  uncontrolled component warning without second part */}
-                onChange={e => handleCheckBox(e)} />
-          <label key={`label${item.id}`}>{item.label}: {item.content}<br/></label>
+        <div className="select-information-checkbox-wrapper" 
+              key={`input-div${item.id}`}>
+          <label key={`label${item.id}`}>{item.label}: {item.content}</label>
+          <label className="select-information-checkbox">
+            <input key={`input${item.id}`}
+                    id={item.id /* passed to update state */}
+                    type="checkbox"
+                    checked={checked[item.id - 1] || false /* was triggering an
+                    uncontrolled component warning without second part */}
+                    onChange={e => handleCheckBox(e)} />
+            <span className="slider"></span>
+          </label>
         </div>
       )}
       </div>
       {/* does nothing yet ... eventually should return `checked` to the QR
         Code Generator, probably? */}
-      <button className="select-submit-button"
+      <button className="select-information-submit-button"
               type="button"
               onClick={handleSubmit}>Generate My QR Code!</button>
     </div>


### PR DESCRIPTION
Styles the select information screen similarly to the edit information screen. Change checkboxes to sliders. Fix erroneous link to generate code on Home screen (should be to select-information).

Resolves #21, related to user story #10.